### PR TITLE
Allow multiple source directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ concern and the application should not know about where it is logging. Blackbox
 is an experiment to decouple syslogging from an application without messing
 about with syslog configuration (which is tricky on BOSH VMs).
 
-Blackbox will tail all files in sub-directories of a specified `source_dir`, and forward any new lines to a syslog server.
+Blackbox will tail all *.log files in sub-directories of the specified source directories and forward any new lines to a syslog server.
+Source directories can be speficified using `source_dir` (single string value) or `source_dirs` (array of strings).
 
 ## Usage
 
@@ -31,6 +32,9 @@ syslog:
     address: logs.example.com:1234
 
   source_dir: /path/to/log-dir
+  source_dirs:
+  - /path/to/logs2
+  - /path/to/logs3
 ```
 
 Consider the case where `log-dir` has the following structure:

--- a/cmd/blackbox/main.go
+++ b/cmd/blackbox/main.go
@@ -36,11 +36,13 @@ func main() {
 	group := grouper.NewDynamic(nil, 0, 0)
 	running := ifrit.Invoke(sigmon.New(group))
 
-	go func() {
-		drainerFactory := syslog.NewDrainerFactory(config.Syslog.Destination, config.Hostname)
-		fileWatcher := blackbox.NewFileWatcher(logger, config.Syslog.SourceDir, group.Client(), drainerFactory)
-		fileWatcher.Watch()
-	}()
+	if config.Syslog.SourceDir != "" {
+		go func() {
+			drainerFactory := syslog.NewDrainerFactory(config.Syslog.Destination, config.Hostname)
+			fileWatcher := blackbox.NewFileWatcher(logger, config.Syslog.SourceDir, group.Client(), drainerFactory)
+			fileWatcher.Watch()
+		}()
+	}
 
 	for _, dir := range config.Syslog.SourceDirs {
 		go func(dir string) {

--- a/cmd/blackbox/main.go
+++ b/cmd/blackbox/main.go
@@ -40,9 +40,9 @@ func main() {
 	group := grouper.NewDynamic(nil, 0, 0)
 	running := ifrit.Invoke(sigmon.New(group))
 
+	drainerFactory := syslog.NewDrainerFactory(config.Syslog.Destination, config.Hostname)
 	if config.Syslog.SourceDir != "" {
 		go func() {
-			drainerFactory := syslog.NewDrainerFactory(config.Syslog.Destination, config.Hostname)
 			fileWatcher := blackbox.NewFileWatcher(logger, config.Syslog.SourceDir, group.Client(), drainerFactory)
 			fileWatcher.Watch()
 		}()
@@ -50,7 +50,6 @@ func main() {
 
 	for _, dir := range config.Syslog.SourceDirs {
 		go func(dir string) {
-			drainerFactory := syslog.NewDrainerFactory(config.Syslog.Destination, config.Hostname)
 			fileWatcher := blackbox.NewFileWatcher(logger, dir, group.Client(), drainerFactory)
 			fileWatcher.Watch()
 		}(dir)

--- a/cmd/blackbox/main.go
+++ b/cmd/blackbox/main.go
@@ -42,6 +42,14 @@ func main() {
 		fileWatcher.Watch()
 	}()
 
+	for _, dir := range config.Syslog.SourceDirs {
+		go func(dir string) {
+			drainerFactory := syslog.NewDrainerFactory(config.Syslog.Destination, config.Hostname)
+			fileWatcher := blackbox.NewFileWatcher(logger, dir, group.Client(), drainerFactory)
+			fileWatcher.Watch()
+		}(dir)
+	}
+
 	err = <-running.Wait()
 	if err != nil {
 		logger.Fatalf("failed: %s", err)

--- a/cmd/blackbox/main.go
+++ b/cmd/blackbox/main.go
@@ -33,6 +33,10 @@ func main() {
 		logger.Fatalf("could not load config file: %s\n", err)
 	}
 
+	if config.Syslog.SourceDir == "" && len(config.Syslog.SourceDirs) == 0 {
+		logger.Fatalf("neither source_dir nor source_dirs have been specified")
+	}
+
 	group := grouper.NewDynamic(nil, 0, 0)
 	running := ifrit.Invoke(sigmon.New(group))
 

--- a/config.go
+++ b/config.go
@@ -37,6 +37,7 @@ func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type SyslogConfig struct {
 	Destination syslog.Drain `yaml:"destination"`
 	SourceDir   string       `yaml:"source_dir"`
+	SourceDirs  []string     `yaml:"source_dirs"`
 }
 
 type Config struct {


### PR DESCRIPTION
Hi. This PR adds an option to specify multiple source directories. To maintain backward compatibility source_dir config option remains unchanged (although becomes optional) while source_dirs array is introduced (also optional). A check was added to make sure at least one of these parameters is specified.

This change is required to forward audit logs from BOSH-managed VMs - while job logs are in /var/vcap/sys/log, audit logs are int /var/log/audit.