### PR TITLE
Allow integration tests to run on Windows

### DIFF
--- a/integration/blackbox.go
+++ b/integration/blackbox.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -108,7 +109,11 @@ func (runner *BlackboxRunner) StartWithConfig(config blackbox.Config, tailerCoun
 }
 
 func (runner *BlackboxRunner) Stop() {
-	ginkgomon.Interrupt(runner.blackboxProcess)
+	if runtime.GOOS == "windows" {
+		ginkgomon.Kill(runner.blackboxProcess)
+	} else {
+		ginkgomon.Interrupt(runner.blackboxProcess)
+	}
 }
 
 func CreateConfigFile(config blackbox.Config) string {


### PR DESCRIPTION
- any subprocess needs to be killed since SIGINT is not a thing on
Windows
- ensure blackboxRunner.Stop() is called at the end of every test
- close logfile before renaming (this is the only way files can be
renamed on Windows)
- in the "tails files when server takes a long time to start" test, use
separate buffers to ensure each server receives the expected data
- when the test TCPSyslogServer is signalled, close the underlying TCP
connection and ignore the resulting io.Copy error
